### PR TITLE
fix: cause deadlock when log level is trace, and fetching apic_id after serial port lock

### DIFF
--- a/src/hvcore/src/hypervisor/serial_logger.rs
+++ b/src/hvcore/src/hypervisor/serial_logger.rs
@@ -46,10 +46,11 @@ impl log::Log for SerialLogger {
             // Disable interrupt while acquiring the mutex, to reduce the chance
             // of reentering this code.
             let _intr_guard = InterruptGuard::new();
+            let _apic_id = apic_id();
             let mut uart = self.port.lock();
             let _ = uart.write_fmt(format_args!(
                 "#{}:{:5}: {}\n",
-                apic_id(),
+                _apic_id,
                 record.level(),
                 record.args()
             ));


### PR DESCRIPTION
Before explaining the problem, thank you for publish the project.
This project has been very helpful for me to understand about hypervisors.

## Deadlock Scenario in Hypervisor Logging

### Detailed Execution Flow:

```
1. Hypervisor initialization complete
   └── Switch to guest mode

2. Guest execution:
   └── log::info!("Virtualized the current processor") call
       ├── serial_logger::log() entry
       ├── InterruptGuard::new() - disable interrupts
       ├── uart.lock() acquired ✓ (Lock #1 held)
       └── format_args! processing calls apic_id()
           └── CPUID 0x1 execution → VM-exit triggered!

3. Host VM-exit handler:
   └── <arch>/guest.rs calls log::trace!() (VM-exit info logging)
       ├── serial_logger::log() entry attempt
       ├── InterruptGuard::new() - already disabled
       └── uart.lock() attempt... ❌ (Lock #1 already held)
           └── Infinite wait (DEADLOCK!)

4. Result:
   - Guest log function holds Lock #1 while waiting for VM-exit completion
   - Host log function waits for Lock #1 release
   - Circular dependency creates deadlock
```

### Call Stack Visualization:
```
Thread/Core 1 Stack:
┌─────────────────────────────────────┐
│ Host: log::trace() - WAITING for lock  │ ← VM-exit handler
├─────────────────────────────────────┤
│ Host: VM-exit processing             │
├─────────────────────────────────────┤
│ Guest: apic_id() → CPUID → VM-exit  │
├─────────────────────────────────────┤
│ Guest: format_args! processing      │
├─────────────────────────────────────┤
│ Guest: uart.lock() - HOLDING lock   │ ← Lock holder
├─────────────────────────────────────┤
│ Guest: log::info() entry            │
└─────────────────────────────────────┘
```

## Pull Request Content

**Title:** Fix: Prevent logging deadlock in VM-exit handlers

**Description:**

### Problem Description

A deadlock occurs when logging from both guest and host contexts due to mutex reentrancy in the serial logger. This happens specifically when:

1. Guest code calls `log::info!()` (e.g., "Virtualized the current processor")
2. Serial logger acquires mutex and calls `apic_id()` for formatting
3. `apic_id()` executes CPUID instruction, triggering VM-exit
4. Host VM-exit handler calls `log::trace!()` for debugging
5. Host logger tries to acquire the same mutex already held by guest context
6. **Deadlock**: Guest waits for VM-exit handling, Host waits for mutex

### Root Cause Analysis

The core issue is **non-reentrant mutex usage across VM-exit boundaries**:

- `spin::Mutex` doesn't support reentrancy (same thread cannot acquire lock twice)
- VM-exit handlers execute in the same CPU context as guest code
- CPUID instruction in `apic_id()` triggers VM-exit while holding the logging mutex
- Host logging attempts to acquire the same mutex, causing deadlock

### Solution

**Move CPUID call outside critical section:**

```rust
fn log(&self, record: &log::Record) {
    if self.enabled(record.metadata()) {
        let _intr_guard = InterruptGuard::new();
        let _apic_id = apic_id();  // ← Call BEFORE acquiring lock
        let mut uart = self.port.lock();
        let _ = uart.write_fmt(format_args!(
            "#{}:{:5}: {}\n",
            _apic_id,  // ← Use stored value
            record.level(),
            record.args()
        ));
    }
}
```

**Benefits:**
- Eliminates most common reentrancy scenario (CPUID in format string)
- Reduces lock hold time
- Maintains existing functionality

### Impact

- **Before**: Hypervisor hangs during guest initialization due to logging deadlock
- **After**: Stable operation with proper VM-exit handling and logging
- **Performance**: Reduced lock contention and critical section time

### Files Changed

- serial_logger.rs: Move `apic_id()` call outside critical section

This fix resolves a critical deadlock that prevented the hypervisor from completing initialization in virtualized environments.